### PR TITLE
feat: enable copying QR scan results

### DIFF
--- a/src/pages/dashboard/Dashboard.module.scss
+++ b/src/pages/dashboard/Dashboard.module.scss
@@ -13,3 +13,19 @@
 .boxmergin {
     margin: 2em 2em 2em 2em;
 }
+
+.scannedInfo {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.scannedText {
+    flex: 1;
+    word-break: break-word;
+}
+
+.copyMessage {
+    margin-top: 8px;
+    font-size: 0.875rem;
+}


### PR DESCRIPTION
### Motivation
Users need to copy QR scan results from the camera view without manually retyping them.

### Design
- Added a copy button with clipboard fallback handling and temporary status messaging to the QR scan banner.
- Styled the scanned payload container and copy status message for readability.

### Tests
- `npm run lint`

### Risks
- Minimal: relies on browser clipboard APIs with a DOM-based fallback.


------
https://chatgpt.com/codex/tasks/task_e_6905a5ad5d488324866d52187c57de86