### PR TITLE
chore(devcontainer): remove codex installation from Dockerfile and up…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,12 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 USER root
 
 RUN apt update -y && \
-    apt install -y curl git sudo zstd make && \
-    \
-    curl -L https://github.com/openai/codex/releases/download/rust-v0.50.0/codex-x86_64-unknown-linux-musl.zst \
-    | zstd -d -o /usr/local/bin/codex && \
-    chmod a+x /usr/local/bin/codex
-
+    apt install -y curl git sudo zstd make
 
 ARG CONTAINER_USERNAME=node
 ARG CONTAINER_USERID=1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,14 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    "onCreateCommand": "mkdir -p /home/node/bin && curl -L https://github.com/openai/codex/releases/download/rust-v0.56.0/codex-x86_64-unknown-linux-musl.zst | zstd -d -o /home/node/bin/codex && chmod a+x /home/node/bin/codex",
     "mounts": [
         "source=${localEnv:HOME}/.codex,target=/home/node/.codex,type=bind,consistency=cached"
     ],
     "workspaceMount": "source=${localWorkspaceFolder},target=/work/${localWorkspaceFolderBasename},type=bind,consistency=cached",
     "workspaceFolder": "/work/${localWorkspaceFolderBasename}",
-    "remoteUser": "node"
+    "remoteUser": "node",
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/home/node/bin"
+    }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ export default {
   darkMode: 'class',
   content: [
     './index.html',
-    './src/**/*.{js,jsx,ts,tsx,html}',
+    './src/**/*.{js,jsx,ts,tsx,html,scss}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
This pull request updates how the `codex` binary is installed in the development container setup, moving the installation from the Docker build process to a runtime command and updating the version. It also ensures the binary is available in the user's path. The most important changes are:

**Dev Environment Setup:**

* The installation of the `codex` binary has been moved from the Dockerfile (`.devcontainer/Dockerfile`) to an `onCreateCommand` in `.devcontainer/devcontainer.json`, which now downloads and installs version `rust-v0.56.0` in the user’s home directory instead of system-wide. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L11-R11) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R5-R14)
* The `PATH` environment variable is updated in `.devcontainer/devcontainer.json` to include `/home/node/bin`, ensuring the newly installed `codex` binary is accessible from the command line for the `node` user.…date devcontainer.json for environment variables