### PR TITLE
chore: remove copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../AGENTS.md


### PR DESCRIPTION
This pull request makes a minor update to the `.github/copilot-instructions.md` file by removing a reference to `../AGENTS.md`. This helps keep documentation links accurate and relevant.